### PR TITLE
Adding Volume Controls

### DIFF
--- a/.config/config.json5
+++ b/.config/config.json5
@@ -11,6 +11,8 @@
       "<Ctrl-d>": "Quit", // Another way to quit
       "<Ctrl-c>": "Quit", // Yet another way to quit
       "<Ctrl-z>": "Suspend", // Suspend the application
+      "<Up>": "IncreaseVolume",
+      "<Down>": "DecreaseVolume",
     },
     "Search": {
       "</>": "HomeMode",

--- a/src/action.rs
+++ b/src/action.rs
@@ -37,4 +37,6 @@ pub enum Action {
     Mode(AppMode),
     SearchMode,
     HomeMode,
+    IncreaseVolume,
+    DecreaseVolume,
 }

--- a/src/components/home.rs
+++ b/src/components/home.rs
@@ -231,6 +231,8 @@ impl Home {
 
             let (shutdown_tx, mut _shutdown_rx) = broadcast::channel(1);
             let download_shutdown_rx = shutdown_tx.subscribe();
+            let play_shutdown_rx = shutdown_tx.subscribe();
+            let volume_shutdown_rx = shutdown_tx.subscribe();
 
             let volume = self.volume;
             let (volume_tx, volume_rx) = broadcast::channel::<f32>(10);
@@ -241,7 +243,13 @@ impl Home {
             let handle = tokio::spawn(async move {
                 tracing::info!("Starting play");
                 play_station
-                    .play(download_shutdown_rx, play_shutdown_tx, volume, volume_rx)
+                    .play(
+                        download_shutdown_rx,
+                        play_shutdown_rx,
+                        volume,
+                        volume_rx,
+                        volume_shutdown_rx,
+                    )
                     .await
                     .unwrap();
                 tracing::info!("Done playing");

--- a/src/components/home.rs
+++ b/src/components/home.rs
@@ -34,6 +34,10 @@ const SELECTED_STYLE_FG: Color = tailwind::BLUE.c300;
 const TEXT_COLOR: Color = tailwind::SLATE.c200;
 const COMPLETED_TEXT_COLOR: Color = tailwind::GREEN.c500;
 
+pub(crate) const VOLUME_MIN: f32 = 0.0;
+pub(crate) const VOLUME_MAX: f32 = 1.0;
+const VOLUME_INCREMENT: f32 = 0.05;
+
 pub struct StreamState {
     station: RadioStation,
     stream_handle: JoinHandle<()>,
@@ -276,8 +280,8 @@ impl Home {
 
     /// Increase volume to a max of `1.0`
     pub fn increase_volume(&mut self) {
-        self.volume += 0.05;
-        self.volume = self.volume.min(1.0);
+        self.volume += VOLUME_INCREMENT;
+        self.volume = self.volume.min(VOLUME_MAX);
 
         if let Some(volume_tx) = &self.volume_tx {
             let _ = volume_tx.send(self.volume);
@@ -286,8 +290,8 @@ impl Home {
 
     /// Decrease volume, to a minimum of `0.0`
     pub fn decrease_volume(&mut self) {
-        self.volume -= 0.05;
-        self.volume = self.volume.max(0.0);
+        self.volume -= VOLUME_INCREMENT;
+        self.volume = self.volume.max(VOLUME_MIN);
 
         if let Some(volume_tx) = &self.volume_tx {
             let _ = volume_tx.send(self.volume);

--- a/src/models/radio_station.rs
+++ b/src/models/radio_station.rs
@@ -18,7 +18,10 @@ use rodio::{Decoder, OutputStream, Sink};
 use serde::{Deserialize, Serialize};
 use tokio::sync::{broadcast, mpsc, Mutex};
 
-use crate::errors::Error;
+use crate::{
+    components::home::{VOLUME_MAX, VOLUME_MIN},
+    errors::Error,
+};
 
 use super::audio_stream::AudioStream;
 
@@ -144,6 +147,7 @@ impl RadioStation {
                     tokio::select! {
                         vol = volume_rx.recv() => {
                             if let Ok(volume) = vol {
+                                let volume = volume.clamp(VOLUME_MIN, VOLUME_MAX);
                                 sink.set_volume(volume);
                             }
                         },


### PR DESCRIPTION
This PR adds volume controls bound to the up and down arrow keys. The current volume is displayed in the title bar at the bottom right and hints have been added to the footer as well. See attached screenshot.

![image](https://github.com/jkellz-dev/voxide/assets/1045189/f332f607-a874-4371-82b0-fcc78bb1e00f)

Minimal changes were  required to manage volume state, all of which are nestled in the `Home` struct. Worth pointing out that this struct received two new properties, one for volume, and the other for the volume channel sender.  The `play` method in `RadioStation` also had to be modified:

* It now takes current volume as an argument
* It now takes a a `volume_shutdown_receiver` 
* It now takes a `volume_receiver `
* An additional volume thread is spun up prior to the blocking shutdown receiver, which takes ownership of `sink` and manipulates volume accordingly
* This additional thread should shutdown properly when a shutdown signal is received